### PR TITLE
Ready

### DIFF
--- a/leti/0303/dvv/1/ChatClient/ChatClient.cpp
+++ b/leti/0303/dvv/1/ChatClient/ChatClient.cpp
@@ -44,7 +44,7 @@ void chat_client::do_read_header()
 void chat_client::do_read_body()
 {
 	boost::asio::async_read(socket_,
-		boost::asio::buffer(read_msg_.body(), read_msg_.body_length()),
+		boost::asio::buffer(read_msg_.body(), read_msg_.body_length()), boost::asio::transfer_all(),
 		[this](boost::system::error_code ec, std::size_t)
 	{
 		if (!ec)

--- a/leti/0303/dvv/1/ChatServer/ChatServer.cpp
+++ b/leti/0303/dvv/1/ChatServer/ChatServer.cpp
@@ -107,7 +107,7 @@ void chat_session::do_read_body()
 {
 	auto self(shared_from_this());
 	boost::asio::async_read(socket_,
-		boost::asio::buffer(read_msg_.body(), read_msg_.body_length()),
+		boost::asio::buffer(read_msg_.body(), read_msg_.body_length()), boost::asio::transfer_all(),
 		[this, self](boost::system::error_code ec, std::size_t)
 	{
 		if (!ec)


### PR DESCRIPTION
1. Добавлена обработка прихода сообщения, разделённого на части.
2. Был задан вопрос: возможна ли ситуация, когда примитив синхронизации находится в разблокированном состоянии на участке кода ChatServer.cpp (строки 59-63).
```
boost::unique_lock<boost::mutex> lock(mutex_);
while (systemMessQueue_.empty()) cond.wait(lock);
chat_message m(systemMessQueue_.front());
cmdWithArg = m().text().substr(start);
systemMessQueue_.pop_front();
```
Ответ: да, т.к. присутствует cond.wait(lock), который будет производить lock/unlock в зависимости от отсутствия/наличия очереди сообщений.